### PR TITLE
feat: Improve CSS parsing and add size check

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest"
+    "test": "vitest",
+    "size": "gzip -c dist/index.js | wc -c"
   },
   "keywords": [
     "css",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,13 @@ function parseCss(css: string): CSSObject {
     } else if (hasColon) {
       i++;
       let valueStart = i;
-      while (i < css.length && css[i] !== ';') i++;
+      let braceLevel = 0;
+      while (i < css.length) {
+        if (css[i] === '(') braceLevel++;
+        else if (css[i] === ')') braceLevel--;
+        else if (css[i] === ';' && braceLevel === 0) break;
+        i++;
+      }
       const value = css.slice(valueStart, i).trim();
       if (before && value) r[toCamelCase(before)] = value;
       if (css[i] === ';') i++;


### PR DESCRIPTION
- Fixes an issue where the CSS parser would incorrectly split data URIs containing semicolons. This resolves failures in tests related to data URIs and URLs with special characters.
- Adds a `size` script to `package.json` to monitor the gzipped size of the library, ensuring it remains under the 1KB target.