### PR TITLE
fix: correctly parse pseudo-classes and pseudo-elements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ function parseCss(css: string): CSSObject {
     while (i < css.length) {
       const c = css[i];
       if (c === '{') break;
-      if (c === ':' && braceLevel === 0) { hasColon = true; break; }
+      if (c === ':' && braceLevel === 0 && /\s/.test(css[i+1] ?? '')) { hasColon = true; break; }
       if (c === ';' && braceLevel === 0) break;
       if (c === '(') braceLevel++;
       if (c === ')') braceLevel--;


### PR DESCRIPTION
The previous implementation failed to correctly parse selectors containing pseudo-classes and pseudo-elements, such as `a:hover::before`. This was because the parser would incorrectly split the selector at the first colon it encountered.

This change fixes the issue by making the parser smarter about where it splits selectors. It now only considers a colon as a property/value separator if it's followed by a whitespace character. This allows it to correctly handle colons that are part of a selector.